### PR TITLE
fix(cicd): SECURITY - https://about.codecov.io/security-update; DISABLED

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,6 @@ jobs:
           git config user.email "github-actions@github.com"
       - name: Build
         run: npx projen build
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          directory: coverage
       - name: Commit and push changes (if any)
         run: 'git diff --exit-code || (git commit -am "chore: self mutation" && git push
           origin HEAD:${{ github.event.pull_request.head.ref }})'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,6 @@ jobs:
         run: npx projen bump
       - name: Build
         run: npx projen build
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          directory: coverage
       - name: Anti-tamper check
         run: git diff --exit-code
       - name: Push commits

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -46,7 +46,6 @@ const project = new AwsCdkConstructLibrary({
 
   gitpod: true,
   docgen: true,
-  codeCov: true,
 
   python: {
     distName: 'p6-namer',


### PR DESCRIPTION
No CVE allocated

https://docs.codecov.io/docs/about-the-codecov-bash-uploader
  `bash <$(curl foo)` strikes again with a fingerprint or checksum check
